### PR TITLE
Add 'SOAPAction' header to requests

### DIFF
--- a/rinse/client.py
+++ b/rinse/client.py
@@ -27,10 +27,11 @@ class SoapClient(object):
             self.__session = requests.Session()
         return self.__session
 
-    def __call__(self, msg, build_response=RinseResponse, debug=False):
+    def __call__(self, msg, action="", build_response=RinseResponse,
+            debug=False):
         """Post 'msg' to remote service."""
         # generate HTTP request from msg
-        request = msg.request(self.url).prepare()
+        request = msg.request(self.url, action).prepare()
         if debug or self.debug:
             print('{} {}'.format(request.method, self.url))
             print(

--- a/rinse/message.py
+++ b/rinse/message.py
@@ -83,13 +83,16 @@ class SoapMessage(object):
         """Generate XML representation of self."""
         return etree.tostring(self.etree(), **kwargs)
 
-    def request(self, url=None):
-        """Genereate a requests.Request instance."""
+    def request(self, url=None, action=None):
+        """Generate a requests.Request instance."""
+        headers = self.http_headers.copy()
+        if action is not None:
+            headers['SOAPAction'] = action
         return requests.Request(
             'POST',
             url or self.url,
             data=self.tostring(pretty_print=True, encoding='utf-8'),
-            headers=self.http_headers,
+            headers=headers
         )
 
     def __bytes__(self):

--- a/rinse/message.py
+++ b/rinse/message.py
@@ -92,7 +92,7 @@ class SoapMessage(object):
             'POST',
             url or self.url,
             data=self.tostring(pretty_print=True, encoding='utf-8'),
-            headers=headers
+            headers=headers,
         )
 
     def __bytes__(self):

--- a/rinse/tests/test_client.py
+++ b/rinse/tests/test_client.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Unit tests for rinse.client module."""
+
+import unittest
+
+from lxml import etree
+from mock import MagicMock, patch
+from rinse.client import SoapClient
+from rinse.message import SoapMessage
+
+
+class TestSoapMessage(unittest.TestCase):
+    def test_soap_action(self):
+        """Test that SOAP-Action HTTP header is set correctly."""
+        msg = SoapMessage(etree.Element('test'))
+        req = msg.request('http://example.com', 'testaction')
+        self.assertEqual(req.headers['SOAPAction'], 'testaction')
+
+    def test_no_soap_action(self):
+        """Test that SOAP-Action HTTP header is absent when no action given.
+        """
+        msg = SoapMessage(etree.Element('test'))
+        req = msg.request('http://example.com')
+        self.assertTrue('SOAPAction' not in req.headers)
+
+    def test_soap_action_is_none(self):
+        """Test that SOAP-Action HTTP header is absent when no action is None.
+        """
+        msg = SoapMessage(etree.Element('test'))
+        req = msg.request('http://example.com', None)
+        self.assertTrue('SOAPAction' not in req.headers)
+
+
+class TestRinseClient(unittest.TestCase):
+    def test_soap_action(self):
+        """Test that SOAP action is passed on to SoapMessage.request()."""
+        msg = SoapMessage(etree.Element('test'))
+        msg.request = MagicMock()
+        with patch('requests.Session') as mock:
+            client = SoapClient('http://example.com')
+            response = client(msg, 'testaction', build_response=lambda r: r)
+            msg.request.assert_called_once_with('http://example.com',
+                                                 'testaction')
+    def test_no_soap_action(self):
+        """Test that empty SOAP action is passed to SoapMessage.request()
+           when no action given."""
+        msg = SoapMessage(etree.Element('test'))
+        msg.request = MagicMock()
+        with patch('requests.Session') as mock:
+            client = SoapClient('http://example.com')
+            response = client(msg, build_response=lambda r: r)
+            msg.request.assert_called_once_with('http://example.com', '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'lxml',
         'requests',
     ],
+    tests_require=['mock'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
Instead of having to add the `SOAPAction` header (required by spec!) to HTTP requests by setting it on the soap message instance, this change allows to specify the value for this header to be passed when calling a `rinse.client.SoapClient` instance as an optional second param (defaults to empty string), which is then passed to `rinse.message.SoapMessage.request`, where it is passed, together with the headers set on the `SoapMessage` instance, to `requests.Request`.

So instead of:

```
msg = SoapMessage(etree.Element('test'))
msg['SOAPAction'] = 'test'
client = SoapClient('<url>')
response = client(msg)
```

you can now write:

```
msg = SoapMessage(etree.Element('test'))
client = SoapClient('<url>')
response = client(msg, 'test')
```

I also fixed a superfluous comma in the `request.Request` instantiation call.

IMHO, you should also be able to specify the URL on a per-request basis, but that would be another PR.