### PR TITLE
Ensure recursive_dict works on legacy python.

### DIFF
--- a/rinse/tests/test_util.py
+++ b/rinse/tests/test_util.py
@@ -3,6 +3,7 @@
 """Unit tests for rinse.util module."""
 
 import unittest
+import six
 from lxml import etree
 
 from ..util import recursive_dict
@@ -10,7 +11,7 @@ from ..util import recursive_dict
 
 class TestRecursiveDict(unittest.TestCase):
     def test_recursive_dict_function(self):
-        doc = etree.fromstring('''<?xml version="1.0" encoding="UTF-8"?>
+        doc = etree.fromstring(six.b('''<?xml version="1.0" encoding="UTF-8"?>
             <SOAP-ENV:Envelope
               xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
               xmlns:ns1="https://example.com/soap/v3"
@@ -30,6 +31,6 @@ class TestRecursiveDict(unittest.TestCase):
                 </ns1:authenticateResponse>
               </SOAP-ENV:Body>
             </SOAP-ENV:Envelope>
-        ''')
+        '''))
 
         recursive_dict(doc)

--- a/rinse/tests/test_util.py
+++ b/rinse/tests/test_util.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Unit tests for rinse.util module."""
+
+import unittest
+from lxml import etree
+
+from ..util import recursive_dict
+
+
+class TestRecursiveDict(unittest.TestCase):
+    def test_recursive_dict_function(self):
+        doc = etree.fromstring('''<?xml version="1.0" encoding="UTF-8"?>
+            <SOAP-ENV:Envelope
+              xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+              xmlns:ns1="https://example.com/soap/v3"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+              SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+              <SOAP-ENV:Body>
+                <ns1:authenticateResponse>
+                  <return xsi:type="ns1:ApiAuthenticateResult">
+                    <token xsi:type="xsd:string">1234567890</token>
+                    <error xsi:type="ns1:ApiError">
+                      <number xsi:type="xsd:int">0</number>
+                      <description xsi:type="xsd:string">No Error</description>
+                    </error>
+                  </return>
+                </ns1:authenticateResponse>
+              </SOAP-ENV:Body>
+            </SOAP-ENV:Envelope>
+        ''')
+
+        recursive_dict(doc)

--- a/rinse/util.py
+++ b/rinse/util.py
@@ -8,6 +8,7 @@ import textwrap
 import defusedxml.lxml
 import lxml.builder
 from lxml import etree
+import six
 
 RINSE_DIR = os.path.dirname(__file__)
 ENVELOPE_XSD = 'soap-1.1_envelope.xsd'
@@ -160,14 +161,13 @@ def recursive_dict(element):
             for child
             in element
         )
+    if six.PY2:
+        kwargs = {'width': 10000}
+    else:
+        kwargs = {'compact': True, 'width': 10000}
     return (
-        '{}{}'.format(
-            element.tag,
-            pprint.pformat(element.attrib, compact=True, width=10000),
-        ),
-        dict(
-            map(recursive_dict, element)
-        ) or element.text
+        '{}{}'.format(element.tag, pprint.pformat(element.attrib, **kwargs)),
+        dict(map(recursive_dict, element)) or element.text
     )
 
 


### PR DESCRIPTION
`compact` kwarg to `pprint.pformat` was added in 3.4.
